### PR TITLE
Removed filtering of lines so that line numbers match where error is in ...

### DIFF
--- a/tasks/lib/lint-inline.js
+++ b/tasks/lib/lint-inline.js
@@ -20,7 +20,7 @@ function removeHTML(src) {
     if (!s) lines[i] = '';
   });
 
-  return lines.filter(Boolean).join('\n');
+  return lines.join('\n');
 }
 
 function createTemporaryFiles(files) {

--- a/test/test.js
+++ b/test/test.js
@@ -43,5 +43,17 @@ exports.inlinelint = {
       });
       test.done();
     });
+  },
+  'test-4': function (test) {
+    test.expect(1);
+    var files = [path.join(fixtures, 'fail.html')];
+    var expected = 9; // hard coded but what to do?
+    var options = {};
+    var tempFiles = lintinline.wrapReporter(jshint, options, files);
+
+    jshint.lint(tempFiles, options, function (results, data) {
+      test.equal(expected, results[0].error.line, 'Should report line numbers in original file');
+    });
+    test.done();
   }
 };


### PR DESCRIPTION
While I get the reason behind the filtering of empty lines is there, on a larger code base - or in massive html-files - it gives much better meaning that errors are reported on the actual line number in the html-file it came from.
Added a test for feature (that might be a bit hard-coded)
