### PR TITLE
Moved grunt.log.ok to after reporterOutput is written

### DIFF
--- a/tasks/lint-inline.js
+++ b/tasks/lint-inline.js
@@ -41,15 +41,7 @@ module.exports = function (grunt) {
 
     // Iterate over the temp files instead of this.filesSrc
     jshint.lint(tempFiles, options, function(results, data) {
-      var failed = 0;
-      if (results.length > 0) {
-        // Fail task if errors were logged except if force was set.
-        failed = force;
-      } else {
-        if (jshint.usingGruntReporter === true && data.length > 0) {
-          grunt.log.ok(data.length + ' file' + (data.length === 1 ? '' : 's') + ' lint free.');
-        }
-      }
+      var failed = results.length > 0;
 
       // Write the output of the reporter if wanted
       if (reporterOutput) {
@@ -61,6 +53,17 @@ module.exports = function (grunt) {
         }
         grunt.file.write(reporterOutput, output);
         grunt.log.ok('Report "' + reporterOutput + '" created.');
+      }
+
+      // has to be after the eventual reporter output since 'usingGruntReporter' 
+      // is true due to reporter reset in wrapReporter to enable mapping file names
+      if (failed) {
+        // Fail task if errors were logged except if force was set.
+        failed = force;
+      } else {
+        if (jshint.usingGruntReporter === true && data.length > 0) {
+          grunt.log.ok(data.length + ' file' + (data.length === 1 ? '' : 's') + ' lint free.');
+        }
       }
 
       done(failed);


### PR DESCRIPTION
...so that we dont get malformed xml-output.

While running inlinelint on TeamCity with attached xml-parser we noticed that builds kept getting red since the 'jslint' output-xml was malformed (but only when no errors were found). 

Tracked it to have to do with the reset of the reporter in _wrapReporter_ which has the consequence of evaluating _jshint.usingGruntReporter_ to true inside the lint-callback.

Moving the output to after eventual output has been written changes nothing of the behaviour.

(and THANKS for an awesome plugin!)
