### PR TITLE
Add new option to apply jshint to all file (not only html files which has script element).

### DIFF
--- a/tasks/lint-inline.js
+++ b/tasks/lint-inline.js
@@ -34,6 +34,10 @@ module.exports = function (grunt) {
     var replacement = options.replacement;
     delete options.replacement;
 
+    // Flag to lint all file or not
+    var lintAllFile = options.lintAllFile;
+    delete options.lintAllFile;
+
     // Hook into stdout to capture report
     var output = '';
     if (reporterOutput) {
@@ -47,7 +51,7 @@ module.exports = function (grunt) {
 
     // Create temporary files for the inline javascript and wrap the reporter
     // to use the real file paths.
-    var tempFiles = lintinline.wrapReporter(jshint, options, this.filesSrc, patterns, replacement);
+    var tempFiles = lintinline.wrapReporter(jshint, options, this.filesSrc, patterns, replacement, lintAllFile);
 
     // Iterate over the temp files instead of this.filesSrc
     jshint.lint(tempFiles, options, function(results, data) {

--- a/test/fixtures/lint_target/fail.html
+++ b/test/fixtures/lint_target/fail.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fixture</title>
+  </head>
+  <body>
+    <script>
+      (function() {
+        var foo = "bar"
+      }(this));
+    </script>
+    <script>
+      (function() {
+        var baz = true;
+      }(this))
+    </script>
+  </body>
+</html>

--- a/test/fixtures/lint_target/fail.js
+++ b/test/fixtures/lint_target/fail.js
@@ -1,0 +1,3 @@
+(function() {
+  var foo = "bar"
+})();

--- a/test/test.js
+++ b/test/test.js
@@ -125,5 +125,35 @@ exports.inlinelint = {
       test.equal(results.length, 2, 'Should lint regular script tags with and without type');
     });
     test.done();
+  },
+  'test-9 lints only files which has inline script': function (test) {
+    test.expect(2);
+    var files     = [path.join(fixtures, 'lint_target', 'fail.html'),
+                     path.join(fixtures, 'lint_target', 'fail.js')];
+    var options   = {};
+    var tempFiles = lintinline.wrapReporter(jshint, options, files, null, null, false);
+
+    jshint.lint(tempFiles, options, function (results, data) {
+      var is_html_file_targeted = results.some(function(result) { var re = /fail\.html/; return re.test(result.file); });
+      var is_js_file_targeted = results.some(function(result) { var re = /fail\.js/; return re.test(result.file); });
+      test.ok(is_html_file_targeted, 'Should target html file');
+      test.ok(!is_js_file_targeted, 'Should not target js file');
+    });
+    test.done();
+  },
+  'test-10 lints all file if lintAllFile flag is true': function (test) {
+    test.expect(2);
+    var files     = [path.join(fixtures, 'lint_target', 'fail.html'),
+                     path.join(fixtures, 'lint_target', 'fail.js')];
+    var options   = {lintAllFile: true};
+    var tempFiles = lintinline.wrapReporter(jshint, options, files, null, null, true);
+
+    jshint.lint(tempFiles, options, function (results, data) {
+      var is_html_file_targeted = results.some(function(result) { var re = /fail\.html/; return re.test(result.file); });
+      var is_js_file_targeted = results.some(function(result) { var re = /fail\.js/; return re.test(result.file); });
+      test.ok(is_html_file_targeted, 'Should target html file');
+      test.ok(is_js_file_targeted, 'Should target js file');
+    });
+    test.done();
   }
 };


### PR DESCRIPTION
This pull-req introduces a new option 'lintAllFile' (boolean, default: false). If this option is enabled, grunt-lint-inline applies jshint not only html files which contains script elements but also all file specified in Gruntfile.js.

The motivation is that I'd like to apply jshint both html and js file at once. Also would like to output result to one file. 

I guess it's better that lint target files are defined at config file (Gruntfile.js), not in a module. Because grunt-contrib-jshint does so (it applies jshint to all file specified in Gruntfile.js). Also we can write complex rule in Gruntfile.js by 'ignores' option or grunt globbing patterns such as '*', '!'.

For backward compatibility I added the option and disable it by default.

Thanks.
