### PR TITLE
Update grunt-contrib-jshint to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
+    "grunt-contrib-jshint": "~0.10.0",
     "temporary": "0.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Would be suitable because a newer version of grunt-contrib-jshint will bring a newer version of jshint and as a consequence will fix that issue I ran into: 

https://github.com/gruntjs/grunt-contrib-jshint/issues/122

(your tests ran successfully)

And thanks for that very handy plugin :+1: 
